### PR TITLE
Officially deprecate Sheduler & RoundRobin and the apply() function

### DIFF
--- a/aiothreading/pool.py
+++ b/aiothreading/pool.py
@@ -30,8 +30,10 @@ from aiologic import Condition, CountdownEvent, SimpleQueue
 from deprecated_params import deprecated_params  # type: ignore[import-untyped]
 
 from .core import Thread
-from .scheduler import Scheduler
 from .types import LoopInitializer, ProxyException, R, T
+
+from deprecation import deprecated
+
 
 MAX_TASKS_PER_CHILD = (
     0  # number of tasks to execute before recycling a child process
@@ -199,12 +201,8 @@ class ThreadPoolResult(Awaitable[Sequence[_T]], AsyncIterable[_T]):
 
 
 @deprecated_params(
-    ["scheduler", "maxtasksperchild", "queuecount"],
-    {
-        "scheduler": "Removed for Performance Optimizations, Scheduled for deletion in 0.1.5",
-        "maxtasksperchild": "Removed for Performance Optimizations, Scheduled for deletion in 0.1.5",
-        "queuecount": "Unused currently, Scheduled for deletion in 0.1.6",
-    },
+    ["queuecount"],
+    "Unused currently, Scheduled for deletion in 0.1.6"
 )
 class ThreadPool:
     """Execute coroutines on a pool of threads."""
@@ -219,10 +217,6 @@ class ThreadPool:
         loop_initializer: Optional[LoopInitializer] = None,
         exception_handler: Optional[Callable[[BaseException], None]] = None,
         *,
-        scheduler: Optional[
-            Scheduler
-        ] = None,  # Scheduler is now Deprecated and no longer in use anymore
-        maxtasksperchild: int = MAX_TASKS_PER_CHILD,
         queuecount: Optional[int] = None,  # queuecount is not used anymore
     ):
         if threads is None:
@@ -237,7 +231,6 @@ class ThreadPool:
         self.initializer = initializer
         self.initargs = initargs
         self.loop_initializer = loop_initializer
-        self.maxtasksperchild = maxtasksperchild
         self.childconcurrency = childconcurrency
         self.exception_handler = exception_handler
 
@@ -272,7 +265,6 @@ class ThreadPool:
 
             thread = ThreadPoolWorker(
                 SimpleQueue(),
-                # self.maxtasksperchild,
                 self.childconcurrency,
                 initializer=self.initializer,
                 initargs=self.initargs,
@@ -308,7 +300,11 @@ class ThreadPool:
 
         return asyncio.wrap_future(future)
 
-    # TODO: Deprecate apply in replacement of submit...
+    @deprecated(
+        deprecated_in="0.1.5",
+        removed_in="0.1.9",
+        details="Use submit() method instead",
+    )
     async def apply(
         self,
         func: Callable[..., Coroutine[Any, Any, R]],

--- a/aiothreading/scheduler.py
+++ b/aiothreading/scheduler.py
@@ -3,22 +3,22 @@
 # 2024 Modified by Vizonex
 
 import itertools
-import warnings
 from abc import ABC, abstractmethod
 from typing import Any, Awaitable, Callable, Dict, Iterator, List, Sequence
 
 from aiologic import SimpleQueue
-
+from deprecation import deprecated
 from .types import QueueID, R, TaskID
 
 
+
 class Scheduler(ABC):
-    def __init__(self) -> None:
-        warnings.warn(
-            "Scheduler & RoundRobin are deprecated and not used anymore, Planned for removal in 0.1.8",
-            DeprecationWarning,
-            stacklevel=3,
-        )
+    @deprecated(
+        "0.1.5",
+        removed_in="0.1.8",
+        details="Shedules have no purpose in aiothreading anymore"
+    )
+    def __init__(self):
         super().__init__()
 
     @abstractmethod
@@ -60,7 +60,11 @@ class Scheduler(ABC):
         Notify the scheduler that a task has been completed.
         """
 
-
+@deprecated(
+    "0.1.5",
+    removed_in="0.1.8",
+    details="Shedules have no purpose in aiothreading anymore"
+)
 class RoundRobin(Scheduler):
     """
     The default scheduling algorithm that assigns tasks to queues in round robin order.
@@ -69,7 +73,11 @@ class RoundRobin(Scheduler):
     accordingly. For example, 12 processes over 8 queues should result in four queues
     receiving double the number tasks compared to the other eight.
     """
-
+    @deprecated(
+        "0.1.5",
+        removed_in="0.1.8",
+        details="Shedules have no purpose in aiothreading anymore"
+    )
     def __init__(self) -> None:
         super().__init__()
         self.qids: List[QueueID] = []

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,8 @@ authors = [
 requires-python = ">=3.9"
 dependencies = [
     "aiologic>=0.13.0",
-    "deprecated-params>=0.1.3"
+    "deprecated-params==0.1.5",
+    'deprecation>=2.1.0'
 ]
 keywords=["aiothreading", "threading", "asyncio"]
 


### PR DESCRIPTION
Going to use the deprecation library to attempt to better warn users about upcoming changes to aiothreading. I also removed 2 keyword parameters and we can get rid of __deprecated-params__ in 0.1.6 unless it's needed in another function in the future.