### PR TITLE
add an automerger workflow for dependabot

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yaml
+++ b/.github/workflows/dependabot-auto-merge.yaml
@@ -1,5 +1,5 @@
 name: Dependabot auto-merge
-on: pull_request_target
+on: pull_request
 
 permissions:
   pull-requests: write

--- a/.github/workflows/dependabot-auto-merge.yaml
+++ b/.github/workflows/dependabot-auto-merge.yaml
@@ -1,0 +1,25 @@
+name: Dependabot auto-merge
+on: pull_request_target
+
+permissions:
+  pull-requests: write
+  contents: write
+
+jobs:
+  dependabot:
+    runs-on: ubuntu-latest
+    if: ${{ github.actor == 'dependabot[bot]' }}
+    # We can be somewhat paitent here. 
+    # But the workflows are extermely fast and takes no more than 2 minutes to complete on success.
+    timeout-minutes: 2
+    steps:
+      - name: Dependabot metadata
+        id: metadata
+        uses: dependabot/fetch-metadata@v3.0.0
+        with:
+          github-token: "${{ secrets.GITHUB_TOKEN }}"
+      - name: Enable auto-merge for Dependabot PRs
+        run: gh pr merge --auto --squash "$PR_URL"
+        env:
+          PR_URL: ${{github.event.pull_request.html_url}}
+          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}

--- a/.github/workflows/dependabot-auto-merge.yaml
+++ b/.github/workflows/dependabot-auto-merge.yaml
@@ -10,8 +10,8 @@ jobs:
     runs-on: ubuntu-latest
     if: ${{ github.actor == 'dependabot[bot]' }}
     # We can be somewhat paitent here. 
-    # But the workflows are extermely fast and takes no more than 2 minutes to complete on success.
-    timeout-minutes: 2
+    # But the workflows are extremely fast and takes no more than 2 minutes to complete on success.
+    timeout-minutes: 4
     steps:
       - name: Dependabot metadata
         id: metadata

--- a/.github/workflows/dependabot-auto-merge.yaml
+++ b/.github/workflows/dependabot-auto-merge.yaml
@@ -9,9 +9,6 @@ jobs:
   dependabot:
     runs-on: ubuntu-latest
     if: github.event.pull_request.user.login == 'dependabot[bot]'
-    # We can be somewhat paitent here. 
-    # But the workflows are extremely fast and takes no more than 4 minutes to complete on success.
-    timeout-minutes: 4
     steps:
       - name: Enable auto-merge for Dependabot PRs
         run: gh pr merge --auto --squash "$PR_URL"

--- a/.github/workflows/dependabot-auto-merge.yaml
+++ b/.github/workflows/dependabot-auto-merge.yaml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     if: ${{ github.actor == 'dependabot[bot]' }}
     # We can be somewhat paitent here. 
-    # But the workflows are extremely fast and takes no more than 2 minutes to complete on success.
+    # But the workflows are extremely fast and takes no more than 4 minutes to complete on success.
     timeout-minutes: 4
     steps:
       - name: Dependabot metadata

--- a/.github/workflows/dependabot-auto-merge.yaml
+++ b/.github/workflows/dependabot-auto-merge.yaml
@@ -13,11 +13,6 @@ jobs:
     # But the workflows are extremely fast and takes no more than 4 minutes to complete on success.
     timeout-minutes: 4
     steps:
-      - name: Dependabot metadata
-        id: metadata
-        uses: dependabot/fetch-metadata@v3.0.0
-        with:
-          github-token: "${{ secrets.GITHUB_TOKEN }}"
       - name: Enable auto-merge for Dependabot PRs
         run: gh pr merge --auto --squash "$PR_URL"
         env:

--- a/.github/workflows/dependabot-auto-merge.yaml
+++ b/.github/workflows/dependabot-auto-merge.yaml
@@ -8,7 +8,7 @@ permissions:
 jobs:
   dependabot:
     runs-on: ubuntu-latest
-    if: ${{ github.actor == 'dependabot[bot]' }}
+    if: github.event.pull_request.user.login == 'dependabot[bot]'
     # We can be somewhat paitent here. 
     # But the workflows are extremely fast and takes no more than 4 minutes to complete on success.
     timeout-minutes: 4


### PR DESCRIPTION
<!-- 
Template comes from aiolibs that I will so happily borrow for our own use-cases - Vizonex 
-->
<!-- Thank you for your contribution! -->

## What do these changes do?

This change automatically merges pull requests from dependabot if all workflows pass This saves a bit of maintenance time for people like you and me. I've already started doing this in.

- [pyllparse parody of llhttp's llparse but for python](https://github.com/Vizonex/pyllparse)
- [deprecated-params](https://github.com/Vizonex/deprecated-params)
- [I believe cyares has one too iirc](https://github.com/Vizonex/cyares)
- winloop although it's use is being decommissioned once uvloop accepts my upcoming pull request which should also affect anyio too in a good way if I'm not mistakened.

If 2 minutes of wait delay is not enough I could make it into 4 minutes of wait time. But I'll let the co-author @x42005e1f decide on this as well as review this PR.

## Are there changes in behavior for the user?

<!-- Outline any notable behaviour for the end users. -->

## Is it a substantial burden for the maintainers to support this?

<!--
Stop right there! Pause. Just for a minute... Can you think of anything
obvious that would complicate the ongoing development of this project?

Try to consider if you'd be able to maintain it throughout the next
5 years. Does it seem viable? Tell us your thoughts! We'd very much
love to hear what the consequences of merging this patch might be...

This will help us assess if your change is something we'd want to
entertain early in the review process. Thank you in advance!
-->

## Related issue number

<!-- Will this resolve any open issues? -->
<!-- Remember to prefix with 'Fixes' if it closes an issue (e.g. 'Fixes #123'). -->

## Checklist
<!-- Remember: This Checklist is important the more you check off and actually perform the 
higher the chance your pull request succeeds. -->

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [x] Documentation reflects the changes
