### PR TITLE
Replace `Runner` in favor of anyio

### DIFF
--- a/aiothreading/core.py
+++ b/aiothreading/core.py
@@ -4,6 +4,7 @@
 # 2025 Modified by x42005e1f
 
 import asyncio
+import sys
 import threading
 from collections.abc import Callable, Coroutine, Generator, Sequence
 from inspect import iscoroutinefunction
@@ -41,9 +42,12 @@ def _asyncio_run(unit: Unit[R]) -> R | Literal[StopEnum.PREMATURE_STOP]:
         except asyncio.CancelledError:
             # Suppress MainTask's cancellation only...
             # On Python<3.11, the method is backported.
-            if not task.cancelling():  # type: ignore[attr-defined]
-                raise
-
+            if sys.version_info >= (3, 11):
+                if not task.cancelling():  # type: ignore[attr-defined]
+                    raise
+            else:
+                if not task.cancelled():
+                    raise
             return StopEnum.PREMATURE_STOP
         finally:
             del task  # break reference cycles

--- a/aiothreading/core.py
+++ b/aiothreading/core.py
@@ -4,12 +4,12 @@
 # 2025 Modified by x42005e1f
 
 import asyncio
-import sys
 import threading
 from collections.abc import Callable, Coroutine, Generator, Sequence
 from inspect import iscoroutinefunction
 from typing import Any, Generic, Literal, NoReturn
 
+import anyio
 from aiologic import Event, Flag
 
 from .types import (
@@ -21,38 +21,43 @@ from .types import (
     Unit,
 )
 
-if sys.version_info >= (3, 11):
-    from asyncio import Runner
-else:
-    from taskgroup import Runner
-
 
 def _asyncio_run(unit: Unit[R]) -> R | Literal[StopEnum.PREMATURE_STOP]:
-    with Runner(loop_factory=unit.loop_initializer) as runner:
-        if unit.initializer:
-            unit.initializer(*unit.initargs)
+    if unit.initializer:
+        unit.initializer(*unit.initargs)
 
-        async def main() -> R | Literal[StopEnum.PREMATURE_STOP]:
-            loop = asyncio.get_running_loop()
-            task = asyncio.current_task()
-            assert task is not None
+    # TODO: When Anyio gets it's next update
+    # It will have a Future Object and new TaskHandle
+    # SEE: https://github.com/agronholm/anyio/pull/1146
 
-            if not unit.stop_flag.set((loop, task)):
-                task.cancel()
+    async def main(unit: Unit[R]) -> R | Literal[StopEnum.PREMATURE_STOP]:
+        loop = asyncio.get_running_loop()
+        task = asyncio.current_task()
+        assert task is not None
+        if not unit.stop_flag.set((loop, task)):
+            task.cancel()
+        try:
+            return await unit.target(*unit.args, **unit.kwargs)
+        except asyncio.CancelledError:
+            # Suppress MainTask's cancellation only...
+            # On Python<3.11, the method is backported.
+            if not task.cancelling():  # type: ignore[attr-defined]
+                raise
 
-            try:
-                return await unit.target(*unit.args, **unit.kwargs)
-            except asyncio.CancelledError:
-                # Suppress MainTask's cancellation only...
-                # On Python<3.11, the method is backported.
-                if not task.cancelling():  # type: ignore[attr-defined]
-                    raise
+            return StopEnum.PREMATURE_STOP
+        finally:
+            del task  # break reference cycles
 
-                return StopEnum.PREMATURE_STOP
-            finally:
-                del task  # break reference cycles
-
-        return runner.run(main())
+    # For now the only acceptable backend is asyncio.
+    # In a later update when anyio adds in a `TaskGroup.create_task()``
+    # function, more of anyio's features will be used and
+    # trio support will be added in.
+    return anyio.run(
+        main,
+        unit,
+        backend_options={"loop_factory": unit.initializer},
+        backend="asyncio",
+    )
 
 
 async def not_implemented(*args: Any, **kwargs: Any) -> NoReturn:
@@ -65,6 +70,7 @@ class Thread(Generic[R]):
 
     __slots__ = ("unit", "aio_thread", "__weakref__")
 
+    # TODO: Rename loop_initializer to loop_factory, be less confusing.
     def __init__(
         self,
         group: None = None,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,6 +10,7 @@ authors = [
 requires-python = ">=3.10"
 dependencies = [
     "aiologic>=0.15.0",
+    "anyio>=4.13.0",
     "taskgroup>=0.2.2; python_version<'3.11'",
 ]
 keywords=["aiothreading", "threading", "asyncio"]


### PR DESCRIPTION
<!-- 
Template comes from aiolibs that I will so happily borrow for our own use-cases - Vizonex 
-->
<!-- Thank you for your contribution! -->

## What do these changes do?

Surprised there wasn't very much in my way from attempting to do this but these changes will now start enabling anyio support and in a future update we will have a `.create_task()` function for anyio's `TaskGroup` but also a `Future` object as well that under development due to my desire to look into hooking pycares to anyio but also separate some of cyares modules into separate libraries also. Were lucky that we even got this far into using anyio and I'm sure users will be happy to see Trio support being added in here also.

## Are there changes in behavior for the user?

The plan will be to rename the `loop_initializer` name to `loop_factory` soon in order to be less confusing so keep that in mind. 
Due to the reason there is a possibility that [deprecated-params](https://github.com/Vizonex/deprecated-params) might make a return unless I see no reason to warn developers these changes it any sooner.  A side note I have is that deprecated-params has been regularly improved since it's last usage with this library and it is now very stable and also mature). 

## Is it a substantial burden for the maintainers to support this?

- I've done this in very small steps to ensure that fully migrating to anyio can be done soon this brings us one step closer to that objective.

## Related issue number

- Related to #21 This will not close it however as the `ThreadPool` will need to be migrated to in a later update.
- Also Related to what has been readily discussed https://github.com/agronholm/anyio/pull/1146

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [x] Documentation reflects the changes
